### PR TITLE
Use only one query to count items in a collection

### DIFF
--- a/lib/active_admin/mongoid/helpers/collection.rb
+++ b/lib/active_admin/mongoid/helpers/collection.rb
@@ -4,13 +4,15 @@ module ActiveAdmin
 
       alias original_collection_size collection_size
       original_collection_size = instance_method(:collection_size)
+
       def collection_size(collection=collection)
-        if(not collection.empty? and collection.first.class.included_modules.include?(Mongoid::Document))
+        if collection.is_a?(::Mongoid::Criteria)
           collection.count(true)
         else
           original_collection_size(collection)
         end
       end
+
     end
   end
 end


### PR DESCRIPTION
Hi Guys,

Is there a reason for firing 3 queries to count items in a collection?

The previous version caused 3 queries:
1. `collection.empty?` #=> load an item to ensure there are items in the collection
2. `collection.first ...` #=> load an item again to be sure about we querying mongo
3. `collection.count(true)` #=> actual count command
